### PR TITLE
Scope siblings to live only

### DIFF
--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -77,11 +77,11 @@ module Spina
     end
 
     def previous_sibling
-      siblings.where("position < ?", position).sorted.last
+      siblings.where("position < ?", position).live.sorted.last
     end
 
     def next_sibling
-      siblings.where("position > ?", position).sorted.first
+      siblings.where("position > ?", position).live.sorted.first
     end
 
     def set_materialized_path


### PR DESCRIPTION
Prevent `draft` pages from showing up in "previous" and "next" siblings.